### PR TITLE
Basic makefile template to get release tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.tmp
+.DS_Store
+.build
+*.swp
+release-tools

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,14 @@
 # limitations under the License.
 
 #CMDS=cosi-controller-manager
-all: build
+all: reltools build
+.PHONY: reltools
+reltools: release-tools/build.make
+release-tools/build.make:
+	$(eval CURDIR := $(shell pwd))
+	$(eval TMP := $(shell mktemp -d))
+	$(shell cd ${TMP} && git clone git@github.com:kubernetes-sigs/container-object-storage-interface-spec.git)
+	$(shell cp -r ${TMP}/container-object-storage-interface-spec/release-tools ${CURDIR}/)
+	$(shell rm -rf ${TMP})  
 
 include release-tools/build.make


### PR DESCRIPTION
Adding the first base template for building controller. Makefile gets release tools to build. .gitignore makes sure release-tools is not checked in into the project.