### PR TITLE
Fix kubeconfig flag

### DIFF
--- a/cmd/controller-manager/controller-manager.go
+++ b/cmd/controller-manager/controller-manager.go
@@ -39,7 +39,7 @@ func init() {
 		c.PersistentFlags().
 			StringVarP(ptr, name, short, dfault, desc)
 	}
-	strFlag(cmd, &kubeConfig, "kube-config", "", kubeConfig, "path to kubeconfig file")
+	strFlag(cmd, &kubeConfig, "kubeconfig", "", kubeConfig, "path to kubeconfig file")
 
 	hideFlag := func(name string) {
 		cmd.PersistentFlags().MarkHidden(name)


### PR DESCRIPTION
Here in the controller flag name is `kubeconfig`, hence here flag name to be fixed

https://github.com/kubernetes-sigs/container-object-storage-interface-api/blob/43539346a903848b3f17aa0f4d41cd827d0070e1/controller/controller.go#L124