### PR TITLE
deploy: use `crds` Kustomization from the API repo

### DIFF
--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -2,26 +2,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-resources:
+bases:
 # CRDs
-- https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-api/master/crds/objectstorage.k8s.io_bucketaccessclasses.yaml
-- https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-api/master/crds/objectstorage.k8s.io_bucketaccesses.yaml
-- https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-api/master/crds/objectstorage.k8s.io_bucketaccessrequests.yaml
-- https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-api/master/crds/objectstorage.k8s.io_bucketclasses.yaml
-- https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-api/master/crds/objectstorage.k8s.io_bucketrequests.yaml
-- https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-api/master/crds/objectstorage.k8s.io_buckets.yaml
+- github.com/kubernetes-sigs/container-object-storage-interface-api/crds
+
+resources:
 # Controller
 - sa.yaml
 - rbac.yaml
 - deployment.yaml
-
-patches:
-# CRDs
-- target:
-    kind: CustomResourceDefinition
-  patch: |-
-    - op: add
-      path: /metadata/annotations
-      value:
-        controller-gen.kubebuilder.io/version: (devel)
-        api-approved.kubernetes.io: https://github.com/kubernetes-sigs/container-object-storage-interface-api/pull/2


### PR DESCRIPTION
Instead of listing all CRD manifests and patching in the required `api-approved` label in a Kustomization within this repository, use the new Kustomization layer from the API repository as a base. This simplifies the deployment machinery in this project.

See: https://github.com/kubernetes-sigs/container-object-storage-interface-api/pull/13