### PR TITLE
move to sigs.k8s.io, remove retry logic in cosi-controller

### DIFF
--- a/cmd/controller-manager/controller-manager.go
+++ b/cmd/controller-manager/controller-manager.go
@@ -10,9 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/kubernetes-sigs/container-object-storage-interface-controller/pkg/bucketaccessrequest"
-	"github.com/kubernetes-sigs/container-object-storage-interface-controller/pkg/bucketrequest"
 	bucketcontroller "sigs.k8s.io/container-object-storage-interface-api/controller"
+	"sigs.k8s.io/container-object-storage-interface-controller/pkg/bucketaccessrequest"
+	"sigs.k8s.io/container-object-storage-interface-controller/pkg/bucketrequest"
 
 	"k8s.io/klog/v2"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubernetes-sigs/container-object-storage-interface-controller
+module sigs.k8s.io/container-object-storage-interface-controller
 
 go 1.15
 
@@ -28,6 +28,6 @@ require (
 	k8s.io/client-go v0.19.4
 	k8s.io/klog/v2 v2.4.0
 	k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd // indirect
-	sigs.k8s.io/container-object-storage-interface-api v0.0.0-20210330175159-2cdabb1a5dc7
+	sigs.k8s.io/container-object-storage-interface-api v0.0.0-20210416205422-83cd0d53ce7f
 	sigs.k8s.io/controller-tools v0.4.1
 )

--- a/go.sum
+++ b/go.sum
@@ -783,8 +783,8 @@ k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9/go.mod h1:dzAXnQbTRyDlZPJX2SUPEqvnB+j7AJjtlox7PEwigU0=
-sigs.k8s.io/container-object-storage-interface-api v0.0.0-20210330175159-2cdabb1a5dc7 h1:M2ZMhWdq9Az8TFj8G6ZffFUpR4XG7Qy8h8ZGsZhi9Xg=
-sigs.k8s.io/container-object-storage-interface-api v0.0.0-20210330175159-2cdabb1a5dc7/go.mod h1:5n4lNKN4uOMW2NTqJ9r8qRAiqh5dZRZB7CNOkFihLfM=
+sigs.k8s.io/container-object-storage-interface-api v0.0.0-20210416205422-83cd0d53ce7f h1:LtkVxN0N+qKHLuYE/N5qxSkJv/3bWkr3+9ZBVwiq1tw=
+sigs.k8s.io/container-object-storage-interface-api v0.0.0-20210416205422-83cd0d53ce7f/go.mod h1:WTzZGS4Q6MdQqDihJdMh2kCvqMx9Amhx0KIainA4lXQ=
 sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210329232956-3bbacbbc9c19 h1:LrLrBCBqO7O/VjJtTrDSj3/f7hLSQaCIouLZFnHGxFg=
 sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210329232956-3bbacbbc9c19/go.mod h1:kafkL5l/lTUrZXhVi/9p1GzpEE/ts29BkWkL3Ao33WU=
 sigs.k8s.io/controller-runtime v0.6.3 h1:SBbr+inLPEKhvlJtrvDcwIpm+uhDvp63Bl72xYJtoOE=

--- a/pkg/bucketaccessrequest/bucketaccessrequest.go
+++ b/pkg/bucketaccessrequest/bucketaccessrequest.go
@@ -7,14 +7,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 
-	"github.com/kubernetes-sigs/container-object-storage-interface-controller/pkg/util"
 	"sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1"
 	bucketclientset "sigs.k8s.io/container-object-storage-interface-api/clientset"
 	bucketcontroller "sigs.k8s.io/container-object-storage-interface-api/controller"
 
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/container-object-storage-interface-controller/pkg/util"
 )
 
 type bucketAccessRequestListener struct {
@@ -144,15 +143,9 @@ func (b *bucketAccessRequestListener) provisionBucketAccess(ctx context.Context,
 		return err
 	}
 
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		bucketAccessRequest.Status.BucketAccessName = bucketaccess.Name
-		bucketAccessRequest.Status.AccessGranted = true
-		_, err := barClient(bucketAccessRequest.Namespace).UpdateStatus(ctx, bucketAccessRequest, metav1.UpdateOptions{})
-		if err != nil {
-			return err
-		}
-		return nil
-	})
+	bucketAccessRequest.Status.BucketAccessName = bucketaccess.Name
+	bucketAccessRequest.Status.AccessGranted = true
+	_, err = barClient(bucketAccessRequest.Namespace).UpdateStatus(ctx, bucketAccessRequest, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/bucketaccessrequest/bucketaccessrequest_test.go
+++ b/pkg/bucketaccessrequest/bucketaccessrequest_test.go
@@ -6,12 +6,12 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/client-go/kubernetes/fake"
+
+	types "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1"
 	bucketclientset "sigs.k8s.io/container-object-storage-interface-api/clientset/fake"
 
-	"github.com/kubernetes-sigs/container-object-storage-interface-controller/pkg/util"
-	types "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1"
+	"sigs.k8s.io/container-object-storage-interface-controller/pkg/util"
 )
 
 var sa1 = v1.ServiceAccount{

--- a/pkg/bucketrequest/bucketrequest_test.go
+++ b/pkg/bucketrequest/bucketrequest_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/client-go/kubernetes/fake"
+
+	types "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1"
 	bucketclientset "sigs.k8s.io/container-object-storage-interface-api/clientset/fake"
 
-	"github.com/kubernetes-sigs/container-object-storage-interface-controller/pkg/util"
-	types "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage.k8s.io/v1alpha1"
+	"sigs.k8s.io/container-object-storage-interface-controller/pkg/util"
 )
 
 var classGoldParameters = map[string]string{


### PR DESCRIPTION
Renamed the module name in the `go.mod` to `sigs.k8s.io/container-object-storage-interface-controller`. I also removed the retry logic in the BAR and BR controllers. 