### PR TITLE
bug 54: finalizer update fix

### DIFF
--- a/pkg/bucketaccessrequest/bucketaccessrequest.go
+++ b/pkg/bucketaccessrequest/bucketaccessrequest.go
@@ -150,9 +150,6 @@ func (b *bucketAccessRequestListener) provisionBucketAccess(ctx context.Context,
 	}
 
 	controllerutil.AddFinalizer(bucketAccessRequest, finalizer)
-	if _, err := b.bucketClient.ObjectstorageV1alpha1().BucketAccessRequests(bucketAccessRequest.Namespace).Update(ctx, bucketAccessRequest, metav1.UpdateOptions{}); err != nil {
-		return err
-	}
 
 	bucketAccessRequest.Status.BucketAccessName = bucketaccess.Name
 	bucketAccessRequest.Status.AccessGranted = true

--- a/pkg/bucketrequest/bucketrequest.go
+++ b/pkg/bucketrequest/bucketrequest.go
@@ -134,9 +134,6 @@ func (b *bucketRequestListener) provisionBucketRequestOperation(ctx context.Cont
 	}
 
 	controllerutil.AddFinalizer(bucketRequest, finalizer)
-	if _, err := b.bucketClient.ObjectstorageV1alpha1().BucketRequests(bucketRequest.Namespace).Update(ctx, bucketRequest, metav1.UpdateOptions{}); err != nil {
-		return err
-	}
 
 	bucketRequest.Status.BucketName = bucket.Name
 	bucketRequest.Status.BucketAvailable = true


### PR DESCRIPTION
This PR removes two calls for the BR and BAR `Update`, since instead we can a single `UpdateStatus` call to handle the update.
This also fixes: #54 