### PR TITLE
implement mvp release tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,36 @@
+#
+# BUILDER
+#
+FROM docker.io/library/golang:1.21.1 AS builder
+
+WORKDIR /buildroot
+
+# Cache deps before building and copying source, so that we don't need to re-download
+# as much and so that source changes don't invalidate our downloaded layer.
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+ENV CGO_ENABLED=0
+
+RUN go build -o artifacts/controller-manager cmd/controller-manager/*.go
+
+
+#
+# FINAL IMAGE
+#
 FROM gcr.io/distroless/static:latest
+
 LABEL maintainers="Kubernetes Authors"
 LABEL description="COSI Controller"
 
-COPY ./bin/controller-manager controller-manager
+LABEL org.opencontainers.image.title="COSI Controller"
+LABEL org.opencontainers.image.description="Container Object Storage Interface (COSI) Controller"
+LABEL org.opencontainers.image.source="https://github.com/kubernetes-sigs/container-object-storage-interface-controller"
+LABEL org.opencontainers.image.licenses="APACHE-2.0"
+
+COPY --from=builder /buildroot/artifacts/controller-manager .
 ENTRYPOINT ["/controller-manager"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,21 +1,28 @@
-# See https://cloud.google.com/cloud-build/docs/build-config
+# GCloud build docs: https://cloud.google.com/cloud-build/docs/build-config
+# Build console:
+#   https://console.cloud.google.com/gcr/images/k8s-staging-test-infra/global/objectstorage-controller
 timeout: 3000s
+options:
+  substitution_option: 'ALLOW_LOOSE'
+  machineType: 'E2_HIGHCPU_8'
 substitutions:
-  _IMAGE_NAME: 'gcr.io/k8s-staging-sig-storage/objectstorage-controller'
+  # GCloud provides som built-in substitution vars:
+  #   https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
+  # K8s provides custom substitutions _GIT_TAG and _PULL_BASE_REF:
+  #   https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md#custom-substitutions
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'master'
-options:
-  substitution_option: ALLOW_LOOSE
 steps:
-- name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221214-1b4dd4d69a"
-  entrypoint: make
-  args: ['build']
-  env:
-  - GIT_TAG=${_GIT_TAG}
-  - PULL_BASE_REF=${_PULL_BASE_REF}
-- name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221214-1b4dd4d69a"
-  entrypoint: make
-  args: ['push']
-  env:
-  - GIT_TAG=${_GIT_TAG}
-  - PULL_BASE_REF=${_PULL_BASE_REF}
+  # it is extremely unclear in GCR docs whether standard gcr.io/cloud-builders/docker builds allow
+  # building multi-arch image manifests as 'docker buildx build' does; therefore, use make buildx
+  # target to be certain multi-arch images are released
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230522-312425ae46'
+    entrypoint: make
+    args: ['buildx']
+    env:
+      - BUILDX_PLATFORMS='linux/amd64,linux/arm64'
+      - IMAGE_TAG='gcr.io/k8s-staging-test-infra/objectstorage-controller:${_GIT_TAG}'
+      - BUILD_ARGS='--tag "gcr.io/k8s-staging-test-infra/objectstorage-controller:latest"'
+images:
+  - gcr.io/k8s-staging-test-infra/objectstorage-controller:${_GIT_TAG}
+  - gcr.io/k8s-staging-test-infra/objectstorage-controller:latest

--- a/resources/deployment.yaml
+++ b/resources/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: objectstorage-controller-sa
       containers:
         - name: objectstorage-controller
-          image: gcr.io/k8s-staging-sig-storage/objectstorage-controller:v20221027-v0.1.1-8-g300019f
+          image: host.minikube.internal:5001/cosi-controller:local-build
           imagePullPolicy: Always
           args:
           - "--v=5"


### PR DESCRIPTION
Implement minimum viable release tooling. Tooling has these goals:

1. `make build` target for local development
2. K8s-compliant GCP cloudbuild config for multi-arch release images
3. allow future use of depandabot with little to no change
4. keep build tooling as simple as possible