### PR TITLE
push images using PROJECT_ID in cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,8 +21,8 @@ steps:
     args: ['buildx']
     env:
       - BUILDX_PLATFORMS='linux/amd64,linux/arm64'
-      - IMAGE_TAG='gcr.io/k8s-staging-test-infra/objectstorage-controller:${_GIT_TAG}'
-      - BUILD_ARGS='--tag "gcr.io/k8s-staging-test-infra/objectstorage-controller:latest"'
+      - IMAGE_TAG='gcr.io/$PROJECT_ID/objectstorage-controller:${_GIT_TAG}'
+      - BUILD_ARGS='--tag "gcr.io/$PROJECT_ID/objectstorage-controller:latest"'
 images:
-  - gcr.io/k8s-staging-test-infra/objectstorage-controller:${_GIT_TAG}
-  - gcr.io/k8s-staging-test-infra/objectstorage-controller:latest
+  - gcr.io/$PROJECT_ID/objectstorage-controller:${_GIT_TAG}
+  - gcr.io/$PROJECT_ID/objectstorage-controller:latest


### PR DESCRIPTION
PROJECT_ID is an env var provided by GCP's Cloudbuild automatically. After further investigation, k8s-staging-test-infra does not seem to house any other Kubernetes SIG images. Other SIGs use `gcr.io/$PROJECT_ID` as the repository base for their images. This should work for the COSI controller as well.

tag: @wlan0 