### PR TITLE
use buildx from cloudbuild directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,7 @@ PLATFORM ?= linux/$(GOARCH)
 BUILDX_PLATFORMS ?= linux/amd64,linux/arm64
 
 ## Image tag for all builds
-IMAGE_TAG ?= local/cosi-controller:latest
-
-## Add additional build args if desired
-BUILD_ARGS ?=
+IMAGE_TAG ?= cosi-controller:latest
 
 ##
 ## === TARGETS === #
@@ -30,11 +27,6 @@ BUILD_ARGS ?=
 build:
 	# $(DOCKER) build --platform $(PLATFORM) --tag $(IMAGE_TAG) .
 	true # return true temporarily to allow prow to succeed
-
-.PHONY: buildx
-## Build cross-platform image for release
-buildx:
-	$(DOCKER) buildx build --platform $(BUILDX_PLATFORMS) $(BUILD_ARGS) --tag $(IMAGE_TAG) .
 
 .PHONY: test
 ## Test packages

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,5 @@
 # GCloud build docs: https://cloud.google.com/cloud-build/docs/build-config
-# Build console:
-#   https://console.cloud.google.com/gcr/images/k8s-staging-test-infra/global/objectstorage-controller
+# Builds go to: https://console.cloud.google.com/gcr/images/k8s-staging-test-infra/global/
 timeout: 3000s
 options:
   substitution_option: 'ALLOW_LOOSE'
@@ -10,19 +9,20 @@ substitutions:
   #   https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
   # K8s provides custom substitutions _GIT_TAG and _PULL_BASE_REF:
   #   https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md#custom-substitutions
-  _GIT_TAG: '12345'
-  _PULL_BASE_REF: 'master'
+  _GIT_TAG: '12345'  # e.g., vYYYYMMDD-hash, vYYYYMMDD-tag, or vYYYYMMDD-tag-n-ghash
+  _PULL_BASE_REF: 'master'  # e.g., master or release-0.2 for a PR merge, or v0.2 for a tag
 steps:
-  # it is extremely unclear in GCR docs whether standard gcr.io/cloud-builders/docker builds allow
-  # building multi-arch image manifests as 'docker buildx build' does; therefore, use make buildx
-  # target to be certain multi-arch images are released
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230522-312425ae46'
-    entrypoint: make
-    args: ['buildx']
-    env:
-      - BUILDX_PLATFORMS='linux/amd64,linux/arm64'
-      - IMAGE_TAG='gcr.io/k8s-staging-sig-storage/objectstorage-controller:${_GIT_TAG}'
-      - BUILD_ARGS='--tag "gcr.io/k8s-staging-sig-storage/objectstorage-controller:latest"'
+  # based on simple build example
+  # https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md
+  - name: gcr.io/cloud-builders/docker
+    # entrypoint: # docker by default
+    args:
+      - buildx
+      - build
+      - --platform="linux/amd64,linux/arm64"
+      - --tag=gcr.io/k8s-staging-sig-storage/objectstorage-controller:${_GIT_TAG}
+      - --tag=gcr.io/k8s-staging-sig-storage/objectstorage-controller:latest
+      - .
 images:
   - gcr.io/k8s-staging-sig-storage/objectstorage-controller:${_GIT_TAG}
   - gcr.io/k8s-staging-sig-storage/objectstorage-controller:latest


### PR DESCRIPTION
It is simpler and likely easier to maintain to have the cloudbuild use `docker buildx build ...` directly rather than to rely on a make target. This makes the build tooling more transparent with fewer layers between the build config and the Dockerfile.