### PR TITLE
allow cloudbuild to build git tags

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,6 @@
 # GCloud build docs: https://cloud.google.com/cloud-build/docs/build-config
-# Builds go to: https://console.cloud.google.com/gcr/images/k8s-staging-test-infra/global/
+# Builds go to https://console.cloud.google.com/gcr/images/k8s-staging-test-infra/global/
+# Build logs in https://testgrid.k8s.io/sig-storage-image-build
 timeout: 3000s
 options:
   substitution_option: 'ALLOW_LOOSE'
@@ -19,10 +20,15 @@ steps:
     args:
       - buildx
       - build
-      - --platform="linux/amd64,linux/arm64"
+      - --platform=linux/amd64,linux/arm64
       - --tag=gcr.io/k8s-staging-sig-storage/objectstorage-controller:${_GIT_TAG}
+      # using _PULL_BASE_REF as a tag will often just build and overwrite the same 'master' tag,
+      # BUT! if the commit has a git tag, it will build that tag instead. this mechanism allows
+      # creating the semver-tagged images that will be auto-promoted to release
+      - --tag=gcr.io/k8s-staging-sig-storage/objectstorage-controller:${_PULL_BASE_REF}
       - --tag=gcr.io/k8s-staging-sig-storage/objectstorage-controller:latest
       - .
 images:
   - gcr.io/k8s-staging-sig-storage/objectstorage-controller:${_GIT_TAG}
+  - gcr.io/k8s-staging-sig-storage/objectstorage-controller:${_PULL_BASE_REF}
   - gcr.io/k8s-staging-sig-storage/objectstorage-controller:latest


### PR DESCRIPTION
Use the K8s-/Prow-provided _PULL_BASE_REF substitution variable [1] to build images with tags based on the git commit tag. By the K8s docs, this should work, but it remains to be tested.

[1] https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md#custom-substitutions