### PR TITLE
cloudbuild: use --load flag to allow pushing images

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,6 +28,7 @@ steps:
     args:
       - buildx
       - build
+      - --load # https://docs.docker.com/build/drivers/docker-container/#loading-to-local-image-store
       - --platform=${_PLATFORMS}
       - --tag=gcr.io/k8s-staging-sig-storage/${_IMAGE}:${_GIT_TAG}
       # using _PULL_BASE_REF as a tag will often just build and overwrite the same 'master' tag,


### PR DESCRIPTION
The cloud build uses the `docker-container` driver which does not make build images available in the local image store by default -- only in the cache. This means the cloud build process doesn't see the images in order to push them at the end. Use the --load flag to fix this.

See: https://docs.docker.com/build/drivers/docker-container/#loading-to-local-image-store