### PR TITLE
add dependabot config for gomod and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups: # batch updates together for fewer dependabot PRs
+      golang-dependencies:
+        patterns:
+          - "github.com/golang*"
+      k8s-dependencies:
+        patterns:
+          - "k8s.io*"
+          - "sigs.k8s.io*"
+      github-dependencies:
+        patterns:
+          - "github.com*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Use dependabot for updating Go module dependencies and docker container images.

Dependabot may need to be enabled in GH repo settings: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates