### PR TITLE
Bump deployments image version to v20231109-v0.1.2-alpha1-8-g7e7b773

### DIFF
--- a/resources/deployment.yaml
+++ b/resources/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: objectstorage-controller-sa
       containers:
         - name: objectstorage-controller
-          image: gcr.io/k8s-staging-sig-storage/objectstorage-controller:v20221027-v0.1.1-8-g300019f
+          image: gcr.io/k8s-staging-sig-storage/objectstorage-controller:v20231102-v0.1.2-alpha1-8-g7e7b773
           imagePullPolicy: Always
           args:
           - "--v=5"

--- a/resources/deployment.yaml
+++ b/resources/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: objectstorage-controller-sa
       containers:
         - name: objectstorage-controller
-          image: gcr.io/k8s-staging-sig-storage/objectstorage-controller:v20231102-v0.1.2-alpha1-8-g7e7b773
+          image: gcr.io/k8s-staging-sig-storage/objectstorage-controller:v20231109-v0.1.2-alpha1-8-g7e7b773
           imagePullPolicy: Always
           args:
           - "--v=5"


### PR DESCRIPTION
The deployment used a older image tag which was not multi-arch. Updated the deployment to the latest tag `v20231109-v0.1.2-alpha1-8-g7e7b773`.

This PR fixes #108 